### PR TITLE
Fixed UML Diagrams link.

### DIFF
--- a/LabWriteupInstructions.md
+++ b/LabWriteupInstructions.md
@@ -37,7 +37,7 @@ This section gives a medium-high level view of the design. This should include t
 
 Label each screenshot and UML diagram with a useful caption. For example: "UML of Data Storage through JSON format" or "The Drop-Down Menu for the Carousel on the Main Page."
 
-See [UML Diagram Guidelines](UmlDiagrams) for more detail on our expectations regarding UML diagrams.
+See [UML Diagram Guidelines](UMLDiagrams) for more detail on our expectations regarding UML diagrams.
 
 ## IV. Questions (8 pts):
 


### PR DESCRIPTION
In the old code for LabWriteupInstructions.md, line 40 had an incorrect link to UmlDiagrams. This file does not exist. So, we changed it to UMLDiagrams, which does exist, and fixed the link. 